### PR TITLE
Updated to poco-1.12.5p2-release.zip

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(poco-example)
 include(FetchContent)
 FetchContent_Declare(
   Poco
-  URL https://github.com/pocoproject/poco/archive/refs/tags/poco-1.10.1-release.zip
+  URL https://github.com/pocoproject/poco/archive/refs/tags/poco-1.12.5p2-release.zip
 )
 FetchContent_MakeAvailable(Poco)
 


### PR DESCRIPTION
Updated to allow compilation which failed with `‘RSA_SSLV23_PADDING’ was not declared in this scope`:

```
.../RSACipherImpl.cpp: In function ‘int Poco::Crypto::{anonymous}::mapPaddingMode(RSAPaddingMode)’:
.../RSACipherImpl.cpp:54:32: error: ‘RSA_SSLV23_PADDING’ was not declared in this scope; did you mean ‘RSA_NO_PADDING’?
   54 |                         return RSA_SSLV23_PADDING;
      |                                ^~~~~~~~~~~~~~~~~~
      |                                RSA_NO_PADDING
```